### PR TITLE
Use json5 in JSON code blocks with comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This example JSON will generate documents every 10 seconds, starting 1 day ago a
 
 This field configures the `hosts` and/or `pods` you would like to generate data for, and what values they should report.
 
-```json
+```json5
 "types": {
   "hosts": {
     // Optional


### PR DESCRIPTION
Adding comments in JSON snippets is helpful, but unfortunately it's rendered as invalid JSON:

<img width="368" alt="image" src="https://user-images.githubusercontent.com/213730/136021813-da40f6c5-4155-4b36-8e44-c9670dc76f75.png">

This PR changes to using a `json5` code block for the JSON snippet with comments in `README.md`. No more flashy red blocks!

<img width="368" alt="image" src="https://user-images.githubusercontent.com/213730/136022141-ca62b1c1-7b8d-4874-9e35-3da978bc1fdd.png">
 