### PR TITLE
fix: Ignore .vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ config.json
 test*.js
 yarn.lock
 *.log
+
+.vscode


### PR DESCRIPTION
This lets me set it to use yarn's copy of typescript without having the outstanding change.