### PR TITLE
add host.os.type and system.diskio.io.time

### DIFF
--- a/configs/hosts.json
+++ b/configs/hosts.json
@@ -27,7 +27,8 @@
         { "name": "cpu", "mean": 0.4, "stdev": 0.1 },
         { "name": "load", "mean": 1, "stdev": 0.1 },
         { "name": "rx", "mean": 1000, "stdev": 500 },
-        { "name": "tx", "mean": 1000, "stdev": 500 }
+        { "name": "tx", "mean": 1000, "stdev": 500 },
+        { "name": "diskIoTime", "mean": 10000000, "stdev": 100000 }
       ]
     }
   }

--- a/configs/pods.json
+++ b/configs/pods.json
@@ -27,7 +27,8 @@
         { "name": "cpu", "mean": 0.4, "stdev": 0.1 },
         { "name": "load", "mean": 1, "stdev": 0.1 },
         { "name": "rx", "mean": 1000, "stdev": 500 },
-        { "name": "tx", "mean": 1000, "stdev": 500 }
+        { "name": "tx", "mean": 1000, "stdev": 500 },
+        { "name": "diskIoTime", "mean": 10000000, "stdev": 100000 }
       ]
     },
     "pods": {
@@ -46,7 +47,8 @@
         { "name": "memory", "mean": 0.6, "stdev": 0 },
         { "name": "cpu", "mean": 0.4, "stdev": 0.1 },
         { "name": "rx", "mean": 1000, "stdev": 500 },
-        { "name": "tx", "mean": 1000, "stdev": 500 }
+        { "name": "tx", "mean": 1000, "stdev": 500 },
+        { "name": "diskIoTime", "mean": 10000000, "stdev": 100000 }
       ]
     }
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,6 +17,13 @@ export const PLATFORMS = [
   'netbsd'
 ];
 
+export const OS_TYPES = [
+  'linux',
+  'macos',
+  'unix',
+  'windows'
+]
+
 export const CLOUD_PROVIDERS = [
   'aws',
   'gcp',

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export const TypeDefRT = rt.intersection([
     offsetBy: rt.number,
     cloudProviders: rt.array(rt.string),
     platforms: rt.array(rt.string),
+    osTypes: rt.array(rt.string),
     cloudRegions: rt.array(rt.string),
     spike: SpikeDefRT,
     normal: NormalDefRT,


### PR DESCRIPTION
Adds `host.os.type` field and `system.diskio.io.time`.  With the Host View I am thinking to switch to using `host.os.type` and we are currently using `system.diskio.io.time`.

https://www.elastic.co/guide/en/ecs/current/ecs-os.html#field-os-type
https://www.elastic.co/guide/en/beats/metricbeat/current/exported-fields-system.html#_diskio_4