### PR TITLE
Update typescript and ts-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint-plugin-react-perf": "^3.2.3",
     "install-peers": "^1.0.3",
     "prettier": "^2.2.0",
-    "ts-node": "^9.0.0",
-    "typescript": "^4.1.3"
+    "ts-node": "^10.7.0",
+    "typescript": "^4.8.4"
   }
 }


### PR DESCRIPTION
Closes https://github.com/elastic/slingshot/issues/25
The PR updates `typescript` and `ts-node` fixes the issue when running the script: 
> Non-string value passed to ts.resolveTypeReferenceDirective, likely by a wrapping package working with an outdated resolveTypeReferenceDirectives signature. This is probably not a problem in TS itself.